### PR TITLE
chore(package): update babel-plugin-transform-react-remove-prop-types to version 0.4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-imports": "^1.5.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.15",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.22",
     "babel-plugin-transform-runtime": "^6.23.0",
     "conventional-changelog-cli": "^2.0.5",
     "conventional-github-releaser": "^3.1.2",


### PR DESCRIPTION
closes #169 